### PR TITLE
Fix builds on non-linux platforms; and add a couple of extra models while here

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -7,7 +7,15 @@ SConsignFile('.sconsign')
 
 env = Environment(ENV={'PATH': os.environ['PATH']})
 
-env.ParseConfig('pkg-config --cflags --libs gl glu glut')
+# Require gl
+env.ParseConfig('pkg-config --cflags --libs gl')
+
+# Merge in glu + glut pkg configs if they exist
+for pkg in ['glu', 'glut']:
+	try:
+		env.ParseConfig('pkg-config --cflags --libs ' + pkg)
+	except Exception:
+		pass
 
 # configure
 if not env.GetOption("clean"):

--- a/SConstruct
+++ b/SConstruct
@@ -1,12 +1,13 @@
 from __future__ import print_function
 
+import os
+
 EnsureSConsVersion(0, 95)
 SConsignFile('.sconsign')
 
+env = Environment(ENV={'PATH': os.environ['PATH']})
 
-env = Environment()
-
-env.ParseConfig('pkg-config --cflags --libs gl')
+env.ParseConfig('pkg-config --cflags --libs gl glu glut')
 
 # configure
 if not env.GetOption("clean"):

--- a/glsnake.c
+++ b/glsnake.c
@@ -594,6 +594,16 @@ static struct model_s model[] = {
        ZERO, RIGHT, LEFT, RIGHT, PIN, ZERO, RIGHT, ZERO, RIGHT, ZERO, RIGHT,
        ZERO, ZERO}}},
 
+    /* Models by stixpjr@gmail.com */
+    {"begging dog",
+      {{ZERO, RIGHT, RIGHT, RIGHT, PIN, LEFT, RIGHT, ZERO, RIGHT,
+	LEFT, PIN, RIGHT, RIGHT, ZERO, LEFT, PIN, LEFT, RIGHT, PIN,
+	RIGHT, LEFT, PIN, LEFT}}},
+    {"swan",
+      {{ZERO, PIN, ZERO, ZERO, ZERO, LEFT, ZERO, LEFT, ZERO, ZERO,
+	RIGHT, PIN, LEFT, ZERO, ZERO, LEFT, PIN, RIGHT, ZERO, ZERO,
+	LEFT, ZERO, LEFT}}},
+
 /* These models come from the website at
  * http://www.geocities.com/stigeide/snake */
 #if 0


### PR DESCRIPTION
pkg-config may live outside of whatever the scons default PATH happens to be; and some platforms require explicit linking against gl, glu & glut.